### PR TITLE
Update distinfo.py

### DIFF
--- a/example-project/packager/distinfo.py
+++ b/example-project/packager/distinfo.py
@@ -23,8 +23,8 @@ def write_metadata(dist_info, name, version):
 
 def _record_row_from_path(path, relative):
     file_data = path.read_bytes()
-    file_hash = base64.urlsafe_b64encode(hashlib.md5(file_data).digest())
-    return [relative.as_posix(), str(len(file_data)), f"md5={file_hash}"]
+    file_hash = base64.urlsafe_b64encode(hashlib.sha256(file_data).digest()).decode().rstrip('=')
+    return [relative.as_posix(), f"sha256={file_hash}", str(len(file_data))]
 
 
 def iter_files(roots):


### PR DESCRIPTION
Hi !
Thank you for your documentation website, it was super informative!! 🚀 

As I was experimenting with the code, I noticed based on my understandings that:
- in RECORD, the order of the CSV is `filename, hash, size`; while in the current code it seems to me the last two are currently inverted.
Ref: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#:~:text=Each%20record%20is%20composed%20of%20three%20elements%3A%20the%20file%E2%80%99s%20path%2C%20the%20hash%20of%20the%20contents%2C%20and%20its%20size

- in RECORD, encoding MD5 is not permitted
Ref: https://peps.python.org/pep-0427/#:~:text=specifically%2C%20md5%20and%20sha1%20are%20not%20permitted

- in record, hashing is to be destripped of trailing `=`
Ref: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#:~:text=encoded%20with%20the%20urlsafe%2Dbase64%2Dnopad%20encoding%20(base64.urlsafe_b64encode(digest)%20with%20trailing%20%3D%20removed

This PR aligns with the reference specifications linked above.

wdyt?

Hope this helps!