### PR TITLE
Fix `build_sdist` documentation

### DIFF
--- a/source/pep517.rst
+++ b/source/pep517.rst
@@ -125,7 +125,7 @@ POSIX.1-2001 pax tar with UTF-8 paths.
 .. literalinclude:: /../example-project/packager/pep517.py
     :caption: packager/pep517.py
     :language: python
-    :lines: 1,49-
+    :lines: 1,42-
 
 Not much we haven't seen here. This is very similar to how we built wheels,
 with only slight differences:


### PR DESCRIPTION
Line 49 is the very end of the file, so the entire body of the `build_sdist` function is missing. I don't know much about reStructuredText, but I think this will fix it.

Thanks for the helpful documentation!

For the record, here's what I see on https://packaging-the-hard-way.readthedocs.io/en/latest/pep517.html as of 2024-01-17:

![image](https://github.com/uranusjr/packaging-the-hard-way/assets/277474/f5d65b20-5b91-466a-bd9f-37581629a5b3)
